### PR TITLE
Add missing function tests

### DIFF
--- a/tests/functions/test_apply_for_axis.py
+++ b/tests/functions/test_apply_for_axis.py
@@ -1,0 +1,30 @@
+import numpy as np
+import torch
+
+import qfeval_functions.functions as QF
+
+
+def manual_apply(f, x, dim):
+    x_move = x.movedim(dim, -1)
+    batch_shape = x_move.shape[:-1]
+    flat = x_move.reshape(int(np.prod(batch_shape)), x.shape[dim])
+    out = f(flat)
+    return out.reshape(batch_shape + (x.shape[dim],)).movedim(-1, dim)
+
+
+def test_apply_for_axis_basic() -> None:
+    x = QF.randn(2, 3, 4)
+    f = lambda t: t ** 2 + 1
+    for dim in range(x.ndim):
+        actual = QF.apply_for_axis(f, x, dim=dim)
+        expected = manual_apply(f, x, dim)
+        assert torch.allclose(actual, expected)
+
+
+def test_apply_for_axis_zero_length() -> None:
+    x = torch.empty(2, 0, 3)
+    f = lambda t: t + 1
+    actual = QF.apply_for_axis(f, x, dim=1)
+    expected = manual_apply(f, x, dim=1)
+    assert actual.shape == expected.shape
+    assert torch.allclose(actual, expected)

--- a/tests/functions/test_eigh.py
+++ b/tests/functions/test_eigh.py
@@ -1,0 +1,12 @@
+import numpy as np
+import torch
+
+import qfeval_functions.functions as QF
+
+
+def test_eigh_cpu() -> None:
+    x = torch.tensor([[2.0, 1.0], [1.0, 2.0]], dtype=torch.float32)
+    w, v = QF.eigh(x)
+    wn, vn = np.linalg.eigh(x.numpy())
+    np.testing.assert_allclose(w.numpy(), wn)
+    np.testing.assert_allclose(v.numpy(), vn, atol=1e-6)

--- a/tests/functions/test_fillna.py
+++ b/tests/functions/test_fillna.py
@@ -1,0 +1,18 @@
+import numpy as np
+import torch
+
+import qfeval_functions.functions as QF
+
+
+def test_fillna_default() -> None:
+    x = torch.tensor([float('nan'), float('inf'), float('-inf')])
+    actual = QF.fillna(x)
+    expected = torch.tensor([0.0, float('inf'), float('-inf')])
+    assert torch.all(torch.eq(actual, expected))
+
+
+def test_fillna_custom() -> None:
+    x = torch.tensor([float('nan'), float('inf'), float('-inf')])
+    actual = QF.fillna(x, nan=1.0, posinf=2.0, neginf=-2.0)
+    expected = torch.tensor([1.0, 2.0, -2.0])
+    assert torch.all(torch.eq(actual, expected))

--- a/tests/functions/test_mstd.py
+++ b/tests/functions/test_mstd.py
@@ -1,0 +1,23 @@
+import numpy as np
+import pandas as pd
+import torch
+
+import qfeval_functions.functions as QF
+
+
+def test_mstd() -> None:
+    x = QF.randn(100)
+    span = 5
+    df = pd.Series(x.numpy())
+    expected = df.rolling(span).std().to_numpy()
+    actual = QF.mstd(x, span=span)
+    np.testing.assert_allclose(actual.numpy(), expected, equal_nan=True, atol=1e-6)
+
+
+def test_mstd_dim1() -> None:
+    x = QF.randn(20, 30)
+    span = 7
+    df = pd.DataFrame(x.numpy())
+    expected = df.rolling(span, axis=1).std().to_numpy()
+    actual = QF.mstd(x, span=span, dim=1)
+    np.testing.assert_allclose(actual.numpy(), expected, equal_nan=True, atol=1e-6)

--- a/tests/functions/test_msum.py
+++ b/tests/functions/test_msum.py
@@ -1,0 +1,23 @@
+import numpy as np
+import pandas as pd
+import torch
+
+import qfeval_functions.functions as QF
+
+
+def test_msum_1d() -> None:
+    x = QF.randn(100)
+    span = 5
+    df = pd.Series(x.numpy())
+    expected = df.rolling(span).sum().to_numpy()
+    actual = QF.msum(x, span=span)
+    np.testing.assert_allclose(actual.numpy(), expected, equal_nan=True, atol=1e-6, rtol=1e-6)
+
+
+def test_msum_dim1() -> None:
+    x = QF.randn(10, 20)
+    span = 4
+    df = pd.DataFrame(x.numpy())
+    expected = df.rolling(span, axis=1).sum().to_numpy()
+    actual = QF.msum(x, span=span, dim=1)
+    np.testing.assert_allclose(actual.numpy(), expected, equal_nan=True, atol=1e-6, rtol=1e-6)

--- a/tests/functions/test_nanones.py
+++ b/tests/functions/test_nanones.py
@@ -1,0 +1,11 @@
+import torch
+
+import qfeval_functions.functions as QF
+
+
+def test_nanones() -> None:
+    x = torch.tensor([[1.0, float('nan')], [float('nan'), 0.0]])
+    actual = QF.nanones(x)
+    expected = torch.tensor([[1.0, float('nan')], [float('nan'), 1.0]])
+    assert torch.all(torch.isnan(actual) == torch.isnan(expected))
+    assert torch.all(torch.nan_to_num(actual) == torch.nan_to_num(expected))

--- a/tests/functions/test_rcum_ops.py
+++ b/tests/functions/test_rcum_ops.py
@@ -1,0 +1,21 @@
+import numpy as np
+import torch
+
+import qfeval_functions.functions as QF
+
+
+def test_rcummax() -> None:
+    x = torch.tensor([[1, 3, 2], [4, 1, 0]], dtype=torch.float32)
+    result = QF.rcummax(x, dim=1)
+    expected_values, expected_indices = torch.cummax(torch.flip(x, [1]), 1)
+    expected_values = torch.flip(expected_values, [1])
+    expected_indices = x.shape[1] - 1 - torch.flip(expected_indices, [1])
+    assert torch.allclose(result.values, expected_values)
+    assert torch.equal(result.indices, expected_indices)
+
+
+def test_rcumsum() -> None:
+    x = QF.randn(5, 4)
+    actual = QF.rcumsum(x, dim=1)
+    expected = torch.flip(torch.cumsum(torch.flip(x, [1]), 1), [1])
+    assert torch.allclose(actual, expected)


### PR DESCRIPTION
## Summary
- add tests for apply_for_axis and zero-length cases
- cover fillna, msum, mstd, nanones, rcummax, rcumsum, and eigh

## Testing
- `make pytest`

------
https://chatgpt.com/codex/tasks/task_e_685035b13e34832a93a6e0a039420442