### PR TITLE
fix: change dim default from () to None for all reduction functions

### DIFF
--- a/qfeval_functions/functions/correl.py
+++ b/qfeval_functions/functions/correl.py
@@ -8,7 +8,7 @@ from .mulmean import mulmean
 def correl(
     x: torch.Tensor,
     y: torch.Tensor,
-    dim: typing.Union[int, typing.Tuple[int, ...]] = (),
+    dim: typing.Union[None, int, typing.Tuple[int, ...]] = None,
     keepdim: bool = False,
 ) -> torch.Tensor:
     r"""Compute Pearson correlation coefficient between two tensors.
@@ -24,10 +24,9 @@ def correl(
             The first input tensor.
         y (Tensor):
             The second input tensor. Must be the same shape as :attr:`x`.
-        dim (int or tuple of ints, optional):
-            The dimension(s) along which to compute the correlation. If not
-            specified (default is empty tuple), computes element-wise
-            correlation and sums the result.
+        dim (None, int, or tuple of ints, optional):
+            The dimension(s) along which to compute the correlation. If None
+            (default), computes element-wise correlation and sums the result.
         keepdim (bool, optional):
             Whether the output tensor has :attr:`dim` retained or not.
             Default is False.

--- a/qfeval_functions/functions/mulmean.py
+++ b/qfeval_functions/functions/mulmean.py
@@ -8,7 +8,7 @@ from .mulsum import mulsum
 def mulmean(
     x: torch.Tensor,
     y: torch.Tensor,
-    dim: typing.Union[int, typing.Tuple[int, ...]] = (),
+    dim: typing.Union[None, int, typing.Tuple[int, ...]] = None,
     keepdim: bool = False,
     *,
     _ddof: int = 0,
@@ -30,9 +30,9 @@ def mulmean(
             The first input tensor.
         y (Tensor):
             The second input tensor. Must be broadcastable with :attr:`x`.
-        dim (int or tuple of ints, optional):
-            The dimension(s) along which to compute the mean. If not specified
-            (default is empty tuple), the mean is computed over all dimensions.
+        dim (None, int, or tuple of ints, optional):
+            The dimension(s) along which to compute the mean. If None
+            (default), the mean is computed over all dimensions.
         keepdim (bool, optional):
             Whether the output tensor has :attr:`dim`
             retained or not. Default is False.

--- a/qfeval_functions/functions/mulsum.py
+++ b/qfeval_functions/functions/mulsum.py
@@ -10,7 +10,7 @@ from .einsum import einsum
 def mulsum(
     x: torch.Tensor,
     y: torch.Tensor,
-    dim: typing.Union[int, typing.Tuple[int, ...]] = (),
+    dim: typing.Union[None, int, typing.Tuple[int, ...]] = None,
     keepdim: bool = False,
     mean: bool = False,
     *,
@@ -29,9 +29,9 @@ def mulsum(
             The first input tensor.
         y (Tensor):
             The second input tensor. Must be broadcastable with :attr:`x`.
-        dim (int or tuple of ints, optional):
+        dim (None, int, or tuple of ints, optional):
             The dimension(s) along which to
-            compute the sum or mean. If not specified (default is empty tuple),
+            compute the sum or mean. If None (default),
             the operation is computed over all dimensions.
         keepdim (bool, optional):
             Whether the output tensor has :attr:`dim`

--- a/qfeval_functions/functions/nancorrel.py
+++ b/qfeval_functions/functions/nancorrel.py
@@ -11,7 +11,7 @@ from .nansum import nansum
 def nancorrel(
     x: torch.Tensor,
     y: torch.Tensor,
-    dim: typing.Union[int, typing.Tuple[int, ...]] = (),
+    dim: typing.Union[None, int, typing.Tuple[int, ...]] = None,
     keepdim: bool = False,
 ) -> torch.Tensor:
     r"""Compute Pearson correlation coefficient between two tensors, ignoring
@@ -41,10 +41,9 @@ def nancorrel(
             The first input tensor.
         y (Tensor):
             The second input tensor. Must be the same shape as :attr:`x`.
-        dim (int or tuple of ints, optional):
-            The dimension(s) along which to compute the correlation. If not
-            specified (default is empty tuple), computes element-wise
-            correlation and sums the result.
+        dim (None, int, or tuple of ints, optional):
+            The dimension(s) along which to compute the correlation. If None
+            (default), computes element-wise correlation and sums the result.
         keepdim (bool, optional):
             Whether the output tensor has :attr:`dim` retained or not.
             Default is False.

--- a/qfeval_functions/functions/nankurtosis.py
+++ b/qfeval_functions/functions/nankurtosis.py
@@ -6,7 +6,7 @@ import torch
 
 def nankurtosis(
     x: torch.Tensor,
-    dim: typing.Union[int, typing.Tuple[int, ...]] = (),
+    dim: typing.Union[None, int, typing.Tuple[int, ...]] = None,
     unbiased: bool = True,
     *,
     fisher: bool = True,
@@ -33,9 +33,9 @@ def nankurtosis(
     Args:
         x (Tensor):
             The input tensor containing values.
-        dim (int or tuple of ints, optional):
-            The dimension(s) along which to compute the kurtosis. If not
-            specified (default is empty tuple), computes over all dimensions.
+        dim (None, int, or tuple of ints, optional):
+            The dimension(s) along which to compute the kurtosis. If None
+            (default), computes over all dimensions.
         unbiased (bool, optional):
             If True (default), uses unbiased estimation
             with bias correction. If False, uses biased estimation.

--- a/qfeval_functions/functions/nanmean.py
+++ b/qfeval_functions/functions/nanmean.py
@@ -5,7 +5,7 @@ import torch
 
 def nanmean(
     x: torch.Tensor,
-    dim: typing.Union[int, typing.Tuple[int, ...]] = (),
+    dim: typing.Union[None, int, typing.Tuple[int, ...]] = None,
     keepdim: bool = False,
 ) -> torch.Tensor:
     r"""Compute the arithmetic mean along specified dimensions, ignoring NaN values.
@@ -26,9 +26,9 @@ def nanmean(
     Args:
         x (Tensor):
             The input tensor containing values.
-        dim (int or tuple of ints, optional):
-            The dimension(s) along which to compute the mean. If not specified
-            (default is empty tuple), the mean is computed over all dimensions.
+        dim (None, int, or tuple of ints, optional):
+            The dimension(s) along which to compute the mean. If None
+            (default), the mean is computed over all dimensions.
         keepdim (bool, optional):
             Whether the output tensor has :attr:`dim` retained or not.
             Default is False.

--- a/qfeval_functions/functions/nanmulmean.py
+++ b/qfeval_functions/functions/nanmulmean.py
@@ -9,7 +9,7 @@ from .mulsum import mulsum
 def nanmulmean(
     x: torch.Tensor,
     y: torch.Tensor,
-    dim: typing.Union[int, typing.Tuple[int, ...]] = (),
+    dim: typing.Union[None, int, typing.Tuple[int, ...]] = None,
     keepdim: bool = False,
     *,
     _ddof: int = 0,
@@ -42,9 +42,9 @@ def nanmulmean(
             The first input tensor.
         y (Tensor):
             The second input tensor. Must be broadcastable with :attr:`x`.
-        dim (int or tuple of ints, optional):
+        dim (None, int, or tuple of ints, optional):
             The dimension(s) along which to
-            compute the mean. If not specified (default is empty tuple), the
+            compute the mean. If None (default), the
             mean is computed over all dimensions.
         keepdim (bool, optional):
             Whether the output tensor has :attr:`dim`

--- a/qfeval_functions/functions/nanmulsum.py
+++ b/qfeval_functions/functions/nanmulsum.py
@@ -10,7 +10,7 @@ from .mulsum import mulsum
 def nanmulsum(
     x: torch.Tensor,
     y: torch.Tensor,
-    dim: typing.Union[int, typing.Tuple[int, ...]] = (),
+    dim: typing.Union[None, int, typing.Tuple[int, ...]] = None,
     keepdim: bool = False,
 ) -> torch.Tensor:
     r"""Compute the sum of element-wise product, ignoring NaN values, in a
@@ -39,9 +39,9 @@ def nanmulsum(
             The first input tensor.
         y (Tensor):
             The second input tensor. Must be broadcastable with :attr:`x`.
-        dim (int or tuple of ints, optional):
-            The dimension(s) along which to compute the sum. If not specified
-            (default is empty tuple), the sum is computed over all dimensions.
+        dim (None, int, or tuple of ints, optional):
+            The dimension(s) along which to compute the sum. If None
+            (default), the sum is computed over all dimensions.
         keepdim (bool, optional):
             Whether the output tensor has :attr:`dim`
             retained or not. Default is False.

--- a/qfeval_functions/functions/nanskew.py
+++ b/qfeval_functions/functions/nanskew.py
@@ -6,7 +6,7 @@ import torch
 
 def nanskew(
     x: torch.Tensor,
-    dim: typing.Union[int, typing.Tuple[int, ...]] = (),
+    dim: typing.Union[None, int, typing.Tuple[int, ...]] = None,
     unbiased: bool = True,
     *,
     keepdim: bool = False,
@@ -32,9 +32,9 @@ def nanskew(
     Args:
         x (Tensor):
             The input tensor containing values.
-        dim (int or tuple of ints, optional):
+        dim (None, int, or tuple of ints, optional):
             The dimension(s) along which to
-            compute the skewness. If not specified (default is empty tuple),
+            compute the skewness. If None (default),
             computes over all dimensions.
         unbiased (bool, optional):
             If True (default), uses unbiased estimation

--- a/qfeval_functions/functions/nanslope.py
+++ b/qfeval_functions/functions/nanslope.py
@@ -11,7 +11,7 @@ from .nansum import nansum
 def nanslope(
     x: torch.Tensor,
     y: torch.Tensor,
-    dim: typing.Union[int, typing.Tuple[int, ...]] = (),
+    dim: typing.Union[None, int, typing.Tuple[int, ...]] = None,
     keepdim: bool = False,
 ) -> torch.Tensor:
     r"""Compute the slope of simple linear regression between two tensors,
@@ -41,9 +41,9 @@ def nanslope(
         y (Tensor):
             The dependent variable tensor (response). Must be broadcastable
             with :attr:`x`.
-        dim (int or tuple of ints, optional):
+        dim (None, int, or tuple of ints, optional):
             The dimension(s) along which to
-            compute the slope. If not specified (default is empty tuple), the
+            compute the slope. If None (default), the
             slope is computed over all dimensions.
         keepdim (bool, optional):
             Whether the output tensor has :attr:`dim`

--- a/qfeval_functions/functions/nansum.py
+++ b/qfeval_functions/functions/nansum.py
@@ -6,7 +6,7 @@ import torch
 
 def nansum(
     x: torch.Tensor,
-    dim: typing.Union[int, typing.Tuple[int, ...]] = (),
+    dim: typing.Union[None, int, typing.Tuple[int, ...]] = None,
     keepdim: bool = False,
 ) -> torch.Tensor:
     r"""Compute the sum of tensor elements along specified dimensions, ignoring
@@ -29,9 +29,9 @@ def nansum(
     Args:
         x (Tensor):
             The input tensor containing values.
-        dim (int or tuple of ints, optional):
-            The dimension(s) along which to compute the sum. If not specified
-            (default is empty tuple), the sum is computed over all dimensions.
+        dim (None, int, or tuple of ints, optional):
+            The dimension(s) along which to compute the sum. If None
+            (default), the sum is computed over all dimensions.
         keepdim (bool, optional):
             Whether the output tensor has :attr:`dim`
             retained or not. Default is False.

--- a/qfeval_functions/functions/nanvar.py
+++ b/qfeval_functions/functions/nanvar.py
@@ -9,7 +9,7 @@ from .nansum import nansum
 
 def nanvar(
     x: torch.Tensor,
-    dim: typing.Union[int, typing.Tuple[int, ...]] = (),
+    dim: typing.Union[None, int, typing.Tuple[int, ...]] = None,
     unbiased: bool = True,
     keepdim: bool = False,
 ) -> torch.Tensor:
@@ -23,9 +23,9 @@ def nanvar(
     Args:
         x (Tensor):
             The input tensor.
-        dim (int or tuple of ints, optional):
-            The dimension(s) along which to compute the variance. If not
-            specified (default is an empty tuple), the variance is computed
+        dim (None, int, or tuple of ints, optional):
+            The dimension(s) along which to compute the variance. If None
+            (default), the variance is computed
             over all elements. Can be a single dimension or multiple dimensions.
         unbiased (bool, optional):
             If ``True`` (default), uses Bessel's correction and divides by

--- a/qfeval_functions/functions/rms.py
+++ b/qfeval_functions/functions/rms.py
@@ -5,7 +5,7 @@ import torch
 
 def rms(
     x: torch.Tensor,
-    dim: typing.Union[int, typing.Tuple[int, ...]] = (),
+    dim: typing.Union[None, int, typing.Tuple[int, ...]] = None,
     keepdim: bool = False,
 ) -> torch.Tensor:
     r"""Returns the root mean square of each row of the input tensor in the
@@ -15,8 +15,9 @@ def rms(
     Args:
         x (Tensor):
             The input tensor.
-        dim (int or tuple of ints):
-            The dimension or dimensions to reduce.
+        dim (None, int, or tuple of ints):
+            The dimension or dimensions to reduce. If None (default),
+            reduces over all dimensions.
         keepdim (bool):
             Whether the output tensor has `dim` retained or not.
 

--- a/qfeval_functions/functions/slope.py
+++ b/qfeval_functions/functions/slope.py
@@ -8,7 +8,7 @@ from .mulmean import mulmean
 def slope(
     x: torch.Tensor,
     y: torch.Tensor,
-    dim: typing.Union[int, typing.Tuple[int, ...]] = (),
+    dim: typing.Union[None, int, typing.Tuple[int, ...]] = None,
     keepdim: bool = False,
 ) -> torch.Tensor:
     r"""Returns the slope of correlation bewteen `x` and `y`.


### PR DESCRIPTION
## 概要

`dim` デフォルト値 `()` を持つreduction関数14個全ての デフォルト値を `None` に変更しました。
numpy, torchに対応関数がないものについても、dimがデフォルトならNoneでreduceするという思想に統一するため、14個全て変更すべきと判断しました。
torch は `dim=()` と `dim=None` を同一に処理するため、挙動の変更はありません。

## 変更

### 変更対象
- `nansum`, `nanmean`, `nanvar`, `nanskew`, `nankurtosis`
- `mulsum`, `mulmean`, `nanmulsum`, `nanmulmean`
- `correl`, `slope`, `nancorrel`, `nanslope`, `rms`

### 変更内容 (どの関数も共通)
- シグネチャ: `dim: Union[int, Tuple[int, ...]] = ()` → `dim: Union[None, int, Tuple[int, ...]] = None`
- docstring: dim の説明を `None` デフォルトに更新

## 補足

- torchはデフォルトをdim=Noneとし、dim=()は2.0以降のドキュメントに登場しない記述であり、本来的にはdim=()でreduceしないべきである一方で、実際の挙動 (version: 2.4)はNoneと同じく全reduceしてしまうようでした。
- `test_nansum.py`, `test_rms.py`, `test_mulsum.py`, `test_mulmean.py` に `dim=()` を明示的にテストするケースがありますが、挙動が変わらないためそのまま残しています。しかし、dim=()はtorch的にも想定外の記法のため、これらのテストは削除しても良いと思っています。